### PR TITLE
Fixed toolbar animation bug in P10

### DIFF
--- a/P10-Keyboard-Input/content.md
+++ b/P10-Keyboard-Input/content.md
@@ -144,14 +144,16 @@ The **MakeSchool ConvenienceKit** helps us out here by wrapping things up a litt
     keyboardNotificationHandler = KeyboardNotificationHandler()
 >        
         keyboardNotificationHandler!.keyboardWillBeHiddenHandler = { (height: CGFloat) in
+            self.toolbarBottomSpace.constant = 0
             UIView.animateWithDuration(0.3, animations: { () -> Void in
-                self.toolbarBottomSpace.constant = 0
+                self.view.layoutIfNeeded()
             })
         }
 >        
         keyboardNotificationHandler!.keyboardWillBeShownHandler = { (height: CGFloat) in
+            self.toolbarBottomSpace.constant = -height
             UIView.animateWithDuration(0.3, animations: { () -> Void in
-                self.toolbarBottomSpace.constant = -height
+                self.view.layoutIfNeeded()
             })
         }
 >

--- a/P11-Search/content.md
+++ b/P11-Search/content.md
@@ -135,7 +135,21 @@ Run the App
 
 ![image](simulator_search.png)
 
-Once again a good time to **Commit your code.**
+Looks great! But if you play around a bit you may discover a pretty serious UX bug.
+
+> [action]
+> Try to find this bug and fix it by yourself. You can do it!
+
+> [solution]
+> When you go into search mode, you hide the navigation bar. But if you tap on a note when you're in search mode, you never re-show the navigation bar; the only way to get back to the Dashboard is to delete the note! 
+> There are a few ways to fix this. One is to make sure the navigation bar is shown every time your `NoteDisplayViewController` appears. To do this, add the following to the `viewWillAppear` method in your `NoteDisplayViewController`:
+>
+    self.navigationController!.setNavigationBarHidden(false, animated: true)
+>
+
+Finding and fixing bugs like this is great practice. No matter how well-thought-out your code is, some things will always slip through the cracks.
+
+Now that we've fixed that, its once again a good time to **Commit your code.**
 
 Well done! You have made it this far and have a fully functional Notes application.  
 Sure, it may not be super pretty and polished yet. However, it's your first App and a great starting place in your development.

--- a/P11-Search/content.md
+++ b/P11-Search/content.md
@@ -54,7 +54,7 @@ Let's add some search functionality. Realm can use `NSPredicate` to filter its r
 >
     func searchNotes(searchString: String) -> RLMResults {
       let searchPredicate = NSPredicate(format: "title CONTAINS[c] %@ OR content CONTAINS[c] %@", searchString, searchString)
-      return Note.objectsWithPredicate(searchPredicate)
+      return Note.objectsWithPredicate(searchPredicate).sortedResultsUsingProperty("modificationDate", ascending: false)
     }
 >
     


### PR DESCRIPTION
The original code didn't actually make the toolbar slide up and down with the keyboard; it just jumped to the right place. This works, although I'm not 100% sure that it's the most elegant way to do it.
